### PR TITLE
build: conditional external dependency for cluster-ui

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -360,7 +360,13 @@ CLUSTER_UI_JS := pkg/ui/cluster-ui/dist/main.js
 
 .SECONDARY: $(CLUSTER_UI_JS)
 $(CLUSTER_UI_JS): $(shell find pkg/ui/workspaces/cluster-ui/src -type f | sed 's/ /\\ /g') pkg/ui/yarn.installed pkg/ui/workspaces/db-console/src/js/protos.d.ts | bin/.submodules-initialized
+	$(NODE_RUN) -C pkg/ui/workspaces/cluster-ui yarn build --db-console-target
+
+# package-cluster-ui target can be used to build cluster-ui package for publishing to NPM registry
+.PHONY: package-cluster-ui
+package-cluster-ui: $(shell find pkg/ui/workspaces/cluster-ui/src -type f | sed 's/ /\\ /g') pkg/ui/yarn.installed pkg/ui/workspaces/db-console/src/js/protos.d.ts
 	$(NODE_RUN) -C pkg/ui/workspaces/cluster-ui yarn build
+	$(NODE_RUN) -C pkg/ui/workspaces/cluster-ui yarn pack --prod
 
 .SECONDARY: pkg/ui/yarn.installed
 pkg/ui/yarn.installed: pkg/ui/package.json pkg/ui/yarn.lock | bin/.submodules-initialized
@@ -1404,7 +1410,7 @@ ui-watch ui-watch-secure: $(UI_CCL_DLLS) pkg/ui/yarn.opt.installed
   #
   # `node-run.sh` wrapper is removed because this command is supposed to be run in dev environment (not in docker of CI)
   # so it is safe to run yarn commands directly to preserve formatting and colors for outputs
-	yarn --cwd pkg/ui/workspaces/cluster-ui build:watch & \
+	yarn --cwd pkg/ui/workspaces/cluster-ui build:watch --db-console-target & \
 	yarn --cwd pkg/ui/workspaces/db-console webpack-dev-server --config webpack.app.js --env.dist=ccl --port $(PORT) --mode "development" $(WEBPACK_DEV_SERVER_FLAGS)
 
 .PHONY: ui-clean

--- a/Makefile
+++ b/Makefile
@@ -1356,10 +1356,10 @@ UI_OSS_MANIFESTS := $(subst .ccl,.oss,$(UI_CCL_MANIFESTS))
 # [1]: http://savannah.gnu.org/bugs/?19108
 .SECONDARY: $(UI_CCL_DLLS) $(UI_CCL_MANIFESTS) $(UI_OSS_DLLS) $(UI_OSS_MANIFESTS)
 
-pkg/ui/workspaces/db-console/dist/%.oss.dll.js pkg/ui/workspaces/db-console/%.oss.manifest.json: pkg/ui/workspaces/db-console/webpack.%.js pkg/ui/yarn.installed $(CLUSTER_UI_JS) $(UI_PROTOS_OSS)
+pkg/ui/workspaces/db-console/dist/%.oss.dll.js pkg/ui/workspaces/db-console/%.oss.manifest.json: pkg/ui/workspaces/db-console/webpack.%.js pkg/ui/yarn.installed $(UI_PROTOS_OSS)
 	$(NODE_RUN) -C pkg/ui/workspaces/db-console $(WEBPACK) -p --config webpack.$*.js --env.dist=oss
 
-pkg/ui/workspaces/db-console/dist/%.ccl.dll.js pkg/ui/workspaces/db-console/%.ccl.manifest.json: pkg/ui/workspaces/db-console/webpack.%.js pkg/ui/yarn.installed $(CLUSTER_UI_JS) $(UI_PROTOS_CCL)
+pkg/ui/workspaces/db-console/dist/%.ccl.dll.js pkg/ui/workspaces/db-console/%.ccl.manifest.json: pkg/ui/workspaces/db-console/webpack.%.js pkg/ui/yarn.installed $(UI_PROTOS_CCL)
 	$(NODE_RUN) -C pkg/ui/workspaces/db-console $(WEBPACK) -p --config webpack.$*.js --env.dist=ccl
 
 .PHONY: ui-test
@@ -1379,7 +1379,7 @@ ui-test-debug: $(UI_DLLS) $(UI_MANIFESTS)
 .SECONDARY: pkg/ui/assets.ccl.installed pkg/ui/assets.oss.installed
 pkg/ui/assets.ccl.installed: $(UI_CCL_DLLS) $(UI_CCL_MANIFESTS) $(UI_JS_CCL) $(shell find pkg/ui/workspaces/db-console/ccl -type f)
 pkg/ui/assets.oss.installed: $(UI_OSS_DLLS) $(UI_OSS_MANIFESTS) $(UI_JS_OSS)
-pkg/ui/assets.%.installed: pkg/ui/workspaces/db-console/webpack.app.js $(shell find pkg/ui/workspaces/db-console/src pkg/ui/workspaces/db-console/styl -type f) | bin/.bootstrap
+pkg/ui/assets.%.installed: pkg/ui/workspaces/db-console/webpack.app.js $(CLUSTER_UI_JS) $(shell find pkg/ui/workspaces/db-console/src pkg/ui/workspaces/db-console/styl -type f) | bin/.bootstrap
 	find pkg/ui/dist$*/assets -mindepth 1 -not -name index.html -delete
 	for dll in $(shell find pkg/ui/workspaces/db-console/dist -name '*.dll.js' -type f); do \
 		echo $$dll | sed -E "s/.oss.dll.js|.ccl.dll.js/.dll.js/" | sed -E "s|^.*\/|pkg/ui/dist$*/assets/|" | xargs -I{} cp $$dll {};\

--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -9,7 +9,7 @@
   "main": "dist/js/main.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
-    "build": "npm-run-all build:typescript build:bundle",
+    "build": "npm-run-all build:typescript \"build:bundle {1}\" --",
     "build:bundle": "NODE_ENV=production webpack --display-error-details --mode=production",
     "build:typescript": "tsc",
     "build:watch": "webpack --watch --mode=development",

--- a/pkg/ui/workspaces/cluster-ui/webpack.config.js
+++ b/pkg/ui/workspaces/cluster-ui/webpack.config.js
@@ -13,121 +13,11 @@ const webpack = require("webpack");
 const WebpackBar = require("webpackbar");
 const MomentLocalesPlugin = require("moment-locales-webpack-plugin");
 
-// tslint:disable:object-literal-sort-keys
-module.exports = {
-  entry: path.resolve(__dirname, "./src/index.ts"),
 
-  output: {
-    path: path.resolve(__dirname, "dist/js"),
-    filename: "main.js",
-    library: "adminUI",
-    libraryTarget: "umd",
-  },
+module.exports = (env, args) => {
+  const dbConsoleTarget = args["dbConsoleTarget"] || false;
 
-  // Enable sourcemaps for debugging webpack's output.
-  devtool: "source-map",
-
-  resolve: {
-    modules: [
-      'node_modules',
-      path.join(__dirname, 'src/fonts'),
-    ],
-    extensions: [".ts", ".tsx", ".js", ".jsx", ".less"],
-    alias: {
-      src: path.resolve(__dirname, "src"),
-    },
-  },
-
-  module: {
-    rules: [
-      {
-        test: /\.(png|jpg|gif|svg|eot|ttf|woff|woff2)$/,
-        use: {
-          loader: "url-loader",
-          options: {
-            limit: true,
-          }
-        },
-      },
-      // Styles in current project use SCSS preprocessing language with CSS modules.
-      // They have to follow file naming convention: [filename].module.scss
-      {
-        test: /\.module\.scss$/,
-        exclude: /node_modules/,
-        use: [
-          "style-loader",
-          {
-            loader: "css-loader",
-            options: {
-              modules: {
-                localIdentName: "[local]--[hash:base64:5]",
-              }
-            },
-          },
-          "sass-loader"
-        ],
-      },
-      // Ant design styles defined as global styles with .scss files which don't follow
-      // internal convention to have .module.scss extension. That's why we need one more sass
-      // loader which matches SCSS files without .module suffix. Note, it doesn't exclude node_modules
-      // dir so it can access external dependencies.
-      {
-        test: /(?<!\.module)\.scss/,
-        use: ["style-loader", "css-loader", "sass-loader"],
-      },
-      {
-        test: /\.(ts|js)x?$/,
-        use: [
-          "babel-loader",
-        ],
-        exclude: /node_modules/,
-      },
-      // Preprocess LESS styles required by external components
-      // (react-select)
-      {
-        use: [
-          "style-loader",
-          "css-loader",
-          {
-            loader: "less-loader",
-            options: {
-              lessOptions: {
-                javascriptEnabled: true
-              }
-            }
-          },
-        ],
-        test: /\.less$/,
-      },
-      // All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
-      {
-        enforce: "pre",
-        test: /\.js$/,
-        loader: "source-map-loader",
-        exclude: /node_modules/,
-      },
-      {test: /\.css$/, use: ["style-loader", "css-loader"]},
-    ],
-  },
-
-  plugins: [
-    new WebpackBar({
-      name: "cluster-ui",
-      color: "cyan",
-      profile: true,
-    }),
-    new MomentLocalesPlugin(),
-    new webpack.NormalModuleReplacementPlugin(
-      /node_modules\/antd\/lib\/style\/index\.less/,
-      path.resolve(__dirname, "src/core/antd-patch.less"),
-    ),
-  ],
-
-  // When importing a module whose path matches one of the following, just
-  // assume a corresponding global variable exists and use that instead.
-  // This is important because it allows us to avoid bundling all of our
-  // dependencies, which allows browsers to cache those libraries between builds.
-  externals: {
+  const externals = {
     protobufjs: "protobufjs",
     react: {
       commonjs: "react",
@@ -146,6 +36,126 @@ module.exports = {
     "redux-saga": "redux-saga",
     "redux": "redux",
     "antd": "antd",
-    "@cockroachlabs/crdb-protobuf-client": "@cockroachlabs/crdb-protobuf-client",
-  },
+  };
+
+  if (dbConsoleTarget) {
+    externals["@cockroachlabs/crdb-protobuf-client"] = "@cockroachlabs/crdb-protobuf-client";
+  }
+
+  // tslint:disable:object-literal-sort-keys
+  return {
+    entry: path.resolve(__dirname, "./src/index.ts"),
+
+    output: {
+      path: path.resolve(__dirname, "dist/js"),
+      filename: "main.js",
+      library: "adminUI",
+      libraryTarget: "umd",
+    },
+
+    // Enable sourcemaps for debugging webpack's output.
+    devtool: "source-map",
+
+    resolve: {
+      modules: [
+        'node_modules',
+        path.join(__dirname, 'src/fonts'),
+      ],
+      extensions: [".ts", ".tsx", ".js", ".jsx", ".less"],
+      alias: {
+        src: path.resolve(__dirname, "src"),
+      },
+    },
+
+    module: {
+      rules: [
+        {
+          test: /\.(png|jpg|gif|svg|eot|ttf|woff|woff2)$/,
+          use: {
+            loader: "url-loader",
+            options: {
+              limit: true,
+            }
+          },
+        },
+        // Styles in current project use SCSS preprocessing language with CSS modules.
+        // They have to follow file naming convention: [filename].module.scss
+        {
+          test: /\.module\.scss$/,
+          exclude: /node_modules/,
+          use: [
+            "style-loader",
+            {
+              loader: "css-loader",
+              options: {
+                modules: {
+                  localIdentName: "[local]--[hash:base64:5]",
+                }
+              },
+            },
+            "sass-loader"
+          ],
+        },
+        // Ant design styles defined as global styles with .scss files which don't follow
+        // internal convention to have .module.scss extension. That's why we need one more sass
+        // loader which matches SCSS files without .module suffix. Note, it doesn't exclude node_modules
+        // dir so it can access external dependencies.
+        {
+          test: /(?<!\.module)\.scss/,
+          use: ["style-loader", "css-loader", "sass-loader"],
+        },
+        {
+          test: /\.(ts|js)x?$/,
+          use: [
+            "babel-loader",
+          ],
+          exclude: /node_modules/,
+        },
+        // Preprocess LESS styles required by external components
+        // (react-select)
+        {
+          use: [
+            "style-loader",
+            "css-loader",
+            {
+              loader: "less-loader",
+              options: {
+                lessOptions: {
+                  javascriptEnabled: true
+                }
+              }
+            },
+          ],
+          test: /\.less$/,
+        },
+        // All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
+        {
+          enforce: "pre",
+          test: /\.js$/,
+          loader: "source-map-loader",
+          exclude: /node_modules/,
+        },
+        {test: /\.css$/, use: ["style-loader", "css-loader"]},
+      ],
+    },
+
+    plugins: [
+      new WebpackBar({
+        name: "cluster-ui",
+        color: "cyan",
+        profile: true,
+      }),
+      new MomentLocalesPlugin(),
+      new webpack.NormalModuleReplacementPlugin(
+        /node_modules\/antd\/lib\/style\/index\.less/,
+        path.resolve(__dirname, "src/core/antd-patch.less"),
+      ),
+    ],
+
+    // When importing a module whose path matches one of the following, just
+    // assume a corresponding global variable exists and use that instead.
+    // This is important because it allows us to avoid bundling all of our
+    // dependencies, which allows browsers to cache those libraries between builds.
+    externals,
+  }
 }

--- a/pkg/ui/workspaces/cluster-ui/webpack.config.js
+++ b/pkg/ui/workspaces/cluster-ui/webpack.config.js
@@ -79,10 +79,6 @@ module.exports = {
         test: /\.(ts|js)x?$/,
         use: [
           "babel-loader",
-          {
-            loader: "astroturf/loader",
-            options: {extension: ".module.scss"},
-          },
         ],
         exclude: /node_modules/,
       },
@@ -149,5 +145,7 @@ module.exports = {
     "react-redux": "react-redux",
     "redux-saga": "redux-saga",
     "redux": "redux",
+    "antd": "antd",
+    "@cockroachlabs/crdb-protobuf-client": "@cockroachlabs/crdb-protobuf-client",
   },
 }

--- a/pkg/ui/workspaces/db-console/webpack.vendor.js
+++ b/pkg/ui/workspaces/db-console/webpack.vendor.js
@@ -15,7 +15,11 @@ const webpack = require("webpack");
 
 const pkg = require("./package.json");
 
-const prodDependencies = Object.keys(pkg.dependencies);
+// exclude "@cockroachlabs/cluster-ui" package from vendor bundle because it is frequently changing code base
+// and should be rebuilt on every change as well.
+const prodDependencies = Object.keys(pkg.dependencies).filter(
+  dep => dep !== "@cockroachlabs/cluster-ui",
+);
 
 // tslint:disable:object-literal-sort-keys
 module.exports = (env, argv) => {


### PR DESCRIPTION
"@cockroachlabs/crdb-protobuf-client" package should be defined as external
dependency for `cluster-ui` webpack configuration only in case it is built
for `db-console`. Otherwise, it `cluster-ui` is built for publishing to
NPM registry, it should include bundled protobufs.

Release note: none

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jordanlewis/cockroach/9)
<!-- Reviewable:end -->
